### PR TITLE
Add an API endpoint to get details on user trophies and points

### DIFF
--- a/src/main/java/com/fcgl/madrid/points/controller/UserController.java
+++ b/src/main/java/com/fcgl/madrid/points/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.fcgl.madrid.points.controller;
 
+import com.fcgl.madrid.points.payload.request.UserId;
 import com.fcgl.madrid.points.payload.response.Response;
 import com.fcgl.madrid.points.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.ResponseEntity;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -23,8 +25,8 @@ public class UserController {
     }
 
     @GetMapping("/summary")
-    public ResponseEntity<Response> getUserData(@NotNull Long userId) {
-        return userService.getUserData(userId);
+    public ResponseEntity<Response> getUserData(@Valid UserId userId) {
+        return userService.getUserData(userId.getUserId());
     }
 
 

--- a/src/main/java/com/fcgl/madrid/points/controller/UserController.java
+++ b/src/main/java/com/fcgl/madrid/points/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.fcgl.madrid.points.controller;
+
+import com.fcgl.madrid.points.payload.response.Response;
+import com.fcgl.madrid.points.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@RestController
+@RequestMapping("/points/user/v1")
+public class UserController {
+
+    private UserService userService;
+
+    @Autowired
+    public void setPostService(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<Response> getUserData(@NotNull Long userId) {
+        return userService.getUserData(userId);
+    }
+
+
+}

--- a/src/main/java/com/fcgl/madrid/points/controller/exceptionHandler/CustomExceptionHandler.java
+++ b/src/main/java/com/fcgl/madrid/points/controller/exceptionHandler/CustomExceptionHandler.java
@@ -1,0 +1,71 @@
+package com.fcgl.madrid.points.controller.exceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fcgl.madrid.points.payload.InternalStatus;
+import com.fcgl.madrid.points.payload.StatusCode;
+import com.fcgl.madrid.points.payload.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@ControllerAdvice
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler{
+
+
+    @Override
+    protected ResponseEntity<Object> handleBindException(
+            BindException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+
+    }
+
+    private ResponseEntity<Object> genericErrorHandler(
+            Exception ex,
+            BindingResult bindingResult,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        List<String> errors = new ArrayList<String>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errors.add(error.getField() + " " + error.getDefaultMessage());
+        }
+        for (ObjectError error : bindingResult.getGlobalErrors()) {
+            errors.add(error.getObjectName() + " " + error.getDefaultMessage());
+        }
+
+        InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, 400, errors);
+        Response loginResponse = new Response<>(internalStatus, null);
+        return handleExceptionInternal(
+                ex, loginResponse, headers, HttpStatus.BAD_REQUEST, request);
+    }
+
+}
+
+

--- a/src/main/java/com/fcgl/madrid/points/payload/request/UserId.java
+++ b/src/main/java/com/fcgl/madrid/points/payload/request/UserId.java
@@ -1,0 +1,21 @@
+package com.fcgl.madrid.points.payload.request;
+
+import javax.validation.constraints.NotNull;
+
+public class UserId {
+
+    @NotNull
+    private Long userId;
+
+    public UserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/points/payload/response/GetUserDataResponse.java
+++ b/src/main/java/com/fcgl/madrid/points/payload/response/GetUserDataResponse.java
@@ -1,0 +1,37 @@
+package com.fcgl.madrid.points.payload.response;
+
+public class GetUserDataResponse {
+    private Integer totalPoints;
+    private Integer tournamentPoints;
+    private Integer trophyCount;
+
+    public GetUserDataResponse(Integer totalPoints, Integer tournamentPoints, Integer trophyCount) {
+        this.totalPoints = totalPoints;
+        this.tournamentPoints = tournamentPoints;
+        this.trophyCount = trophyCount;
+    }
+
+    public Integer getTotalPoints() {
+        return totalPoints;
+    }
+
+    public void setTotalPoints(Integer totalPoints) {
+        this.totalPoints = totalPoints;
+    }
+
+    public Integer getTournamentPoints() {
+        return tournamentPoints;
+    }
+
+    public void setTournamentPoints(Integer tournamentPoints) {
+        this.tournamentPoints = tournamentPoints;
+    }
+
+    public Integer getTrophyCount() {
+        return trophyCount;
+    }
+
+    public void setTrophyCount(Integer trophyCount) {
+        this.trophyCount = trophyCount;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/points/payload/response/Response.java
+++ b/src/main/java/com/fcgl/madrid/points/payload/response/Response.java
@@ -1,0 +1,41 @@
+package com.fcgl.madrid.points.payload.response;
+
+import com.fcgl.madrid.points.payload.InternalStatus;
+
+import java.time.Instant;
+
+public class Response<T> {
+    private T response;
+    private InternalStatus status;
+    private Long timestamp;
+
+    public Response(InternalStatus status, T response) {
+        this.status = status;
+        this.response = response;
+        this.timestamp = Instant.now().toEpochMilli();
+    }
+
+    public T getResponse() {
+        return response;
+    }
+
+    public void setResponse(T response) {
+        this.response = response;
+    }
+
+    public InternalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(InternalStatus status) {
+        this.status = status;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/points/repository/UserTrophyRepository.java
+++ b/src/main/java/com/fcgl/madrid/points/repository/UserTrophyRepository.java
@@ -15,4 +15,7 @@ public interface UserTrophyRepository extends JpaRepository<UserTrophy, Long> {
     List<UserTrophy> getUserTrophiesById(Long id);
 
     Optional<UserTrophy> getByUserId(Long userId);
+
+    Integer countByUserId(Long userId);
+
 }

--- a/src/main/java/com/fcgl/madrid/points/service/UserService.java
+++ b/src/main/java/com/fcgl/madrid/points/service/UserService.java
@@ -1,0 +1,61 @@
+package com.fcgl.madrid.points.service;
+
+import com.fcgl.madrid.points.payload.response.GetUserDataResponse;
+import com.fcgl.madrid.points.payload.response.GetUserPointsResponse;
+import com.fcgl.madrid.points.dataModel.UserPoint;
+import com.fcgl.madrid.points.payload.response.Response;
+import com.fcgl.madrid.points.repository.UserPointsRepository;
+import com.fcgl.madrid.points.payload.InternalStatus;
+import com.fcgl.madrid.points.payload.StatusCode;
+import com.fcgl.madrid.points.repository.UserTrophyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
+import java.util.List;
+
+import java.lang.Exception;
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private UserPointsRepository userPointsRepository;
+    private UserTrophyRepository userTrophyRepository;
+
+    @Autowired
+    public UserService(UserPointsRepository userPointsRepository, UserTrophyRepository userTrophyRepository) {
+        this.userPointsRepository = userPointsRepository;
+        this.userTrophyRepository = userTrophyRepository;
+    }
+
+    @CircuitBreaker(name = "backendA", fallbackMethod = "fallback")
+    public ResponseEntity<Response> getUserData(Long userId) {
+        UserPoint userPoint = null;
+        Optional<UserPoint> optionalUserPoint = userPointsRepository.getByUserId(userId);
+        if (!optionalUserPoint.isPresent()) {
+            UserPoint newUserPoint = new UserPoint(userId, 0, 0);
+            userPointsRepository.save(newUserPoint);
+            userPoint = newUserPoint;
+        } else {
+            userPoint = optionalUserPoint.get();
+        }
+        Integer trophyCount = userTrophyRepository.countByUserId(userId);
+        GetUserDataResponse userDataResponse = new GetUserDataResponse(
+                userPoint.getTotalPoints(),
+                userPoint.getTournamentPoints(),
+                trophyCount
+        );
+        Response<GetUserDataResponse> response = new Response<>(InternalStatus.OK, userDataResponse);
+        return  new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private ResponseEntity<Response> fallback(Long userId, Exception ex) {
+        String message = "Fallback: " + ex.getMessage();
+        InternalStatus internalStatus = new InternalStatus(StatusCode.UNKNOWN, 500, message);
+        Response response = new Response<>(internalStatus, null);
+        return new ResponseEntity<Response>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## Problem
 
Currently we have to make two separate API requests to get details on the UserPoints data and the UserTrophy data. There is a screen in the native app that requires both data points. But we don't want to make two API request for API latency concerns

## Solution

Introduce an API that returns data on UserPoints and UserTrophy

## Test

Test out the API and confirm that userPoints userTournamentPoints and TrophyCount for a user is returned correctly.
