### PR TITLE
Trophy Table Update with emoji name, Data Population for UserPoint

### DIFF
--- a/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
+++ b/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
@@ -1,10 +1,7 @@
 package com.fcgl.madrid.dev;
 
 import com.fcgl.madrid.points.dataModel.*;
-import com.fcgl.madrid.points.repository.ActionRepository;
-import com.fcgl.madrid.points.repository.TrophyRepository;
-import com.fcgl.madrid.points.repository.UserPointHistoryRepository;
-import com.fcgl.madrid.points.repository.UserPointsRepository;
+import com.fcgl.madrid.points.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,16 +16,19 @@ public class DataPopulation {
     private TrophyRepository trophyRepository;
     private UserPointHistoryRepository userPointHistoryRepository;
     private UserPointsRepository userPointsRepository;
+    private UserTrophyRepository userTrophyRepository;
 
     @Autowired
     public DataPopulation(ActionRepository actionRepository,
                           TrophyRepository trophyRepository,
                           UserPointHistoryRepository userPointHistoryRepository,
-                          UserPointsRepository userPointsRepository) {
+                          UserPointsRepository userPointsRepository,
+                          UserTrophyRepository userTrophyRepository) {
         this.actionRepository = actionRepository;
         this.trophyRepository = trophyRepository;
         this.userPointHistoryRepository = userPointHistoryRepository;
         this.userPointsRepository = userPointsRepository;
+        this.userTrophyRepository = userTrophyRepository;
     }
 
     @Transactional
@@ -43,8 +43,23 @@ public class DataPopulation {
         actionRepository.save(recommendingToAFriend);
 
         // Trophy #1, the user has to do action #1 x3 times to earn this trophy
-        Trophy trophy = new Trophy(100, "/no/where", "King of Receipts", addingAReceipt, 3);
+        Trophy trophy = new Trophy(100, "/no/where", "King of Receipts", addingAReceipt, 3, "baby_bottle");
+        Trophy trophy2 = new Trophy(100, "/no/where", "King of Popcorn", addingAReceipt, 2, "popcorn");
+        Trophy trophy3 = new Trophy(50, "/no/where", "King of Forum", addingAReceipt, 2, "ribbon");
+        Trophy trophy4 = new Trophy(25, "/no/where", "King of Toast", addingAReceipt, 2, "balloon");
         trophyRepository.save(trophy);
+        trophyRepository.save(trophy2);
+        trophyRepository.save(trophy3);
+        trophyRepository.save(trophy4);
+
+        UserTrophy userTrophy = new UserTrophy(1L, trophy, 1);
+        UserTrophy userTrophy2 = new UserTrophy(1L, trophy2, 1);
+        UserTrophy userTrophy3 = new UserTrophy(1L, trophy3, 1);
+        UserTrophy userTrophy4 = new UserTrophy(1L, trophy4, 1);
+        userTrophyRepository.save(userTrophy);
+        userTrophyRepository.save(userTrophy2);
+        userTrophyRepository.save(userTrophy3);
+        userTrophyRepository.save(userTrophy4);
 
 
         UserPoint userPoint = new UserPoint(1L, 100,  50);

--- a/src/main/java/com/fcgl/madrid/points/controller/UserTrophyController.java
+++ b/src/main/java/com/fcgl/madrid/points/controller/UserTrophyController.java
@@ -1,5 +1,6 @@
 package com.fcgl.madrid.points.controller;
 
+import com.fcgl.madrid.points.payload.request.UserId;
 import com.fcgl.madrid.points.payload.response.GetUserTrophyResponse;
 import com.fcgl.madrid.points.dataModel.UserTrophy;
 import com.fcgl.madrid.points.service.UserTrophyService;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.ResponseEntity;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -20,8 +22,8 @@ public class UserTrophyController {
     DevService devService;
 
     @GetMapping("/userTrophies")
-    public ResponseEntity<GetUserTrophyResponse> getUserTrophiesById(Long userId) {
-        return userTrophyService.getUserTrophiesById(userId);
+    public ResponseEntity<GetUserTrophyResponse> getUserTrophiesById(@Valid UserId userId) {
+        return userTrophyService.getUserTrophiesById(userId.getUserId());
     }
 
     @Autowired

--- a/src/main/java/com/fcgl/madrid/points/dataModel/Trophy.java
+++ b/src/main/java/com/fcgl/madrid/points/dataModel/Trophy.java
@@ -1,5 +1,7 @@
 package com.fcgl.madrid.points.dataModel;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import javax.persistence.*;
 
 @Entity
@@ -13,22 +15,25 @@ public class Trophy extends AuditModel {
     private String imageFileLocation;
     private String description;
     private int actionCount;
+    private String emojiName;
 
     @OneToOne
     @JoinColumn(name = "trophy_action_id")
+    @JsonBackReference
     private Action action;
 
     public Trophy() {
 
     }
 
-    public Trophy(int numberOfPoints, String imageFileLocation, String description, Action action, int actionCount) {
+    public Trophy(int numberOfPoints, String imageFileLocation, String description, Action action, int actionCount, String emojiName) {
         this.numberOfPoints = numberOfPoints;
         this.imageFileLocation = imageFileLocation;
         this.description = description;
 
         this.action = action;
         this.actionCount = actionCount;
+        this.emojiName = emojiName;
     }
 
     public Long getId() {
@@ -113,5 +118,13 @@ public class Trophy extends AuditModel {
 
     public void setActionCount(int actionCount) {
         this.actionCount = actionCount;
+    }
+
+    public String getEmojiName() {
+        return emojiName;
+    }
+
+    public void setEmojiName(String emojiName) {
+        this.emojiName = emojiName;
     }
 }


### PR DESCRIPTION
## Problem

We don't currently have any images of emojis for the trophies

## Solution

We don't need the images, we just need the emoji name. The native app can then get the respective emoji. This will save us some data by not having to save images in our database

1. Trophy table now has an **emojiName** column. 
2. Added some trophies and User Trophies to the DataPopulation packager testing purposes on development app

emoji names can be found here: https://unicodey.com/emoji-data/table.htm

## Testing
1. Make an API call to get user trophies. 
    * Confirm that you are able to see the emojiName